### PR TITLE
Fix issue with transfer to a internal object like conference, queue, parking

### DIFF
--- a/agi-bin/returnontransfer_setContext.php
+++ b/agi-bin/returnontransfer_setContext.php
@@ -29,19 +29,31 @@ global $db;
 
 $agi = new AGI();
 $extension = $argv[1];
+$callernum = $argv[2];
+$blindnum = $argv[3];
 
-//get park extension
-$sql = "SELECT parkext from parkplus;";
-$data=@$db->getRow($sql);
-$park_ext = $data[0];
-if($park_ext == $extension) {
-    @$agi->exec("Set", "xfer_context=from-internal");
-    exit (0);
-}
-
-//get context
+//get xfer dest context
 $sql2 = "SELECT data FROM sip where keyword=\"context\" and id=\"$extension\";";
 $result = @$db->getRow($sql2);
-$context = $result[0];
-@$agi->exec("Set", "xfer_context=$context");
+$extension_context = $result[0];
 
+//check context of xfer dest
+if($extension_context!='') {
+         @$agi->exec("Set", "xfer_context=$extension_context");
+} else {
+         //get caller context
+         $sql3 = "SELECT data FROM sip where keyword=\"context\" and id=\"$callernum\";";
+         $result = @$db->getRow($sql3);
+         $callerid_context = $result[0];
+
+         //check context of caller
+         if ($callerid_context!='') {
+                @$agi->exec("Set", "xfer_context=$callerid_context");
+         } else {
+                //get blind context
+                $sql4 = "SELECT data FROM sip where keyword=\"context\" and id=\"$blindnum\";";
+                $result = @$db->getRow($sql4);
+                $blind_context = $result[0];
+                @$agi->exec("Set", "xfer_context=$blind_context");
+         }
+}

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -38,23 +38,26 @@ function returnontransfer_get_config($engine){
             $context = 'blindxfer_ringback';
             $e = '_X.';
             $ext->add($context,$e,'',new ext_noop('${BLINDTRANSFER}'));
+            $ext->add($context,$e,'', new ext_set('blind','${CUT(BLINDTRANSFER,-,1)}'));
+            $ext->add($context,$e,'', new ext_set('blind_exten','${CUT(foo,/,2)}'));
+            $ext->add($context,$e,'',new ext_noop('${blind_exten}'));
             $ext->add($context,$e,'', new ext_set('timeoutd',$timeout)); // Set timeout
             $ext->add($context,$e,'', new ext_set('CHANNEL(language)', '${MASTER_CHANNEL(CHANNEL(language))}'));
-            $ext->add($context,$e,'', new ext_set('xfer_exten','${EXTEN}'));           
+            $ext->add($context,$e,'', new ext_set('xfer_exten','${EXTEN}'));
             $ext->add($context,$e,'',new ext_noop('${xfer_exten}'));
-            $ext->add($context,$e,'',new ext_agi('returnontransfer_setContext.php,${xfer_exten}'));
+            $ext->add($context,$e,'',new ext_agi('returnontransfer_setContext.php,${xfer_exten},${CALLERID(num)},${blind_exten}'));
             $ext->add($context,$e,'',new ext_noop('${xfer_context}'));
             $ext->add($context,$e,'',new ext_dial('local/${EXTEN}@${xfer_context}','${timeoutd}'));
             $ext->add($context,$e,'',new ext_noop('${BLINDTRANSFER}'));
-            $ext->add($context,$e,'', new ext_set('foo','${CUT(BLINDTRANSFER,-,1)}'));           
-            $ext->add($context,$e,'', new ext_set('cb_exten','${CUT(foo,/,2)}')); 
+            $ext->add($context,$e,'', new ext_set('foo','${CUT(BLINDTRANSFER,-,1)}'));
+            $ext->add($context,$e,'', new ext_set('cb_exten','${CUT(foo,/,2)}'));
             $ext->add($context,$e,'',new ext_noop('${cb_exten}'));
             $ext->add($context,$e,'',new ext_gotoif('$["${DIALSTATUS}" = "ANSWER"]','hangup:callback'));
             $ext->add($context,$e,'callback', new ext_set('CALLERID(name)',$prefix)); # Set prefix to indicate it is a ringback
             if (isset($alertinfo) && !empty($alertinfo) && $alertinfo != "") {
                 $ext->add($context,$e,'', new ext_setvar('__ALERT_INFO', $alertinfo));
             }
-            $ext->add($context,$e,'',new ext_agi('returnontransfer_setContext.php,${cb_exten}'));
+            $ext->add($context,$e,'',new ext_agi('returnontransfer_setContext.php,${cb_exten},${CALLERID(num)}'));
             $ext->add($context,$e,'',new ext_noop('${xfer_context}'));
             $ext->add($context,$e,'',new ext_dial('local/${cb_exten}@${xfer_context},'));
             $ext->add($context,$e,'hangup',new ext_hangup(''));


### PR DESCRIPTION
Return on transfer doesn't work if the destination of transfer is an object that hasn't a context.
Queue, conference, parking, for example, don't have a context.
Without a context, the command that generates the call (Dial) fails.
With this fix, the contexts of the called, the caller and the recipient of the transfer are evaluated, in this way a context that can be used to transfer the call and for the possible return is surely found.
