### PR TITLE
Add check also for trunk context

### DIFF
--- a/agi-bin/returnontransfer_setContext.php
+++ b/agi-bin/returnontransfer_setContext.php
@@ -55,6 +55,14 @@ if($extension_context!='') {
     $sth = $db->prepare($sql4);
     $sth->execute(array(':blindnum' => $blindnum));
     $blind_context = $sth->fetch(\PDO::FETCH_COLUMN);
+    if (empty($blind_context)) {
+            # Search for context in trunks
+            $sql5 = "SELECT data FROM pjsip where `keyword`='context' and `id` = (SELECT `id` FROM pjsip WHERE trunk_name = :blindnum)";
+            $sth = $db->prepare($sql5);
+            $sth->execute(array(':blindnum' => $blindnum));
+            $blind_context = $sth->fetch(\PDO::FETCH_COLUMN);
+    }
     @$agi->exec("Set", "xfer_context=$blind_context");
   }
 }
+


### PR DESCRIPTION
Also check the Trunk context when resolving the transfer context, since an extension using a modified dial string (e.g., PJSIP/TRUNK_NAME) can initiate a transfer.